### PR TITLE
Xml midi matching

### DIFF
--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -704,7 +704,7 @@ class Note(object):
     self.pitch = None               # Tuple (Pitch Name, MIDI number)
     self.note_duration = NoteDuration(state)
     self.state = state
-    self.tied = False
+    self.tie = False
     self._parse()
 
   def _parse(self):
@@ -736,10 +736,10 @@ class Note(object):
       elif child.tag == 'unpitched':
         raise UnpitchedNoteException('Unpitched notes are not supported')
       elif child.tag == 'tie':
-        if self.tied ==False:
-          self.tied = child.attrib['type']
+        if self.tie ==False:
+          self.tie = child.attrib['type']
         else:
-          self.tied = 'start_stop'
+          self.tie = 'start_stop'
       else:
         # Ignore other tag types because they are not relevant to Magenta.
         pass

--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -704,6 +704,7 @@ class Note(object):
     self.pitch = None               # Tuple (Pitch Name, MIDI number)
     self.note_duration = NoteDuration(state)
     self.state = state
+    self.tied = False
     self._parse()
 
   def _parse(self):
@@ -734,6 +735,11 @@ class Note(object):
         self._parse_tuplet(child)
       elif child.tag == 'unpitched':
         raise UnpitchedNoteException('Unpitched notes are not supported')
+      elif child.tag == 'tie':
+        if self.tied ==False:
+          self.tied = child.attrib['type']
+        else:
+          self.tied = 'start_stop'
       else:
         # Ignore other tag types because they are not relevant to Magenta.
         pass
@@ -812,7 +818,7 @@ class Note(object):
       # Raise exception for unknown step (ex: 'Q')
       raise PitchStepParseException('Unable to parse pitch step ' + step)
 
-    pitch_class = (pitch_class + int(alter)) % 12
+    pitch_class = pitch_class + int(alter)
     midi_pitch = (12 + pitch_class) + (int(octave) * 12)
     return midi_pitch
 


### PR DESCRIPTION
parse tie and save it in note class
(False, ‘start’, ‘stop’, ‘start_stop’)

string pitch to MIDI pitch error fixed