### PR TITLE
Edit musicxml_parser.py fix pitch error

### DIFF
--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -812,7 +812,7 @@ class Note(object):
       # Raise exception for unknown step (ex: 'Q')
       raise PitchStepParseException('Unable to parse pitch step ' + step)
 
-    pitch_class = (pitch_class + int(alter)) % 12
+    pitch_class = pitch_class + int(alter)
     midi_pitch = (12 + pitch_class) + (int(octave) * 12)
     return midi_pitch
 


### PR DESCRIPTION
xml에서 midi_pitch를 얻을 때, 잘 못 mapping되는 것을 수정 (ex: C4 b -> b4 #)

