### PR TITLE
Feat: Add new barline, repeat properties in Measure class

### DIFF
--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -508,8 +508,8 @@ class Measure(object):
     self.tempos = []
     self.time_signature = None
     self.key_signature = None
-    self.barline = None
-    self.repeat = None        # 'start' or 'stop' or None
+    self.barline = None            # 'double' or 'final' or None
+    self.repeat = None             # 'start' or 'stop' or None
     # Cumulative duration in MusicXML duration.
     # Used for time signature calculations
     self.duration = 0
@@ -554,7 +554,6 @@ class Measure(object):
         # Sum up the MusicXML durations in voice 1 of this measure
         if note.voice == 1 and not note.is_in_chord:
           self.duration += note.note_duration.duration
-
       else:
         # Ignore other tag types because they are not relevant.
         pass

--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -531,7 +531,6 @@ class Measure(object):
       elif child.tag == 'backup':
         self._parse_backup(child)
       elif child.tag == 'barline':
-        # Get text in <bar-style /> and update barline
         self._parse_barline(child)
       elif child.tag == 'direction':
         # Append new direction
@@ -559,7 +558,7 @@ class Measure(object):
         pass
 
   def _parse_barline(self, xml_barline):
-    """Parse the MusicXML <bar-style> element.
+    """Parse the MusicXML <barline> element.
 
     Args:
       xml_barline: XML element with tag type 'barline'.

--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -535,6 +535,9 @@ class Measure(object):
         self._parse_direction(child)
       elif child.tag == 'forward':
         self._parse_forward(child)
+      elif child.tag == 'harmony':
+        chord_symbol = ChordSymbol(child, self.state)
+        self.chord_symbols.append(chord_symbol)
       elif child.tag == 'note':
         # Add direction if find note 
         note = Note(child, direction, self.state)
@@ -546,12 +549,9 @@ class Measure(object):
         # Sum up the MusicXML durations in voice 1 of this measure
         if note.voice == 1 and not note.is_in_chord:
           self.duration += note.note_duration.duration
-      elif child.tag == 'harmony':
-        chord_symbol = ChordSymbol(child, self.state)
-        self.chord_symbols.append(chord_symbol)
 
       else:
-        # Ignore other tag types because they are not relevant to Magenta.
+        # Ignore other tag types because they are not relevant.
         pass
 
   def _parse_attributes(self, xml_attributes):
@@ -582,6 +582,8 @@ class Measure(object):
           if new_key > 6:
             new_key %= -6
           self.key_signature.key = new_key
+
+        
       else:
         # Ignore other tag types because they are not relevant to Magenta.
         pass
@@ -606,7 +608,6 @@ class Measure(object):
   def _parse_direction(self, xml_direction):
     """Parse the MusicXML <direction> element."""
     for child in xml_direction:
-      #print(child)
       if child.tag == 'sound':
         if child.get('tempo') is not None:
           tempo = Tempo(self.state, child)
@@ -615,10 +616,6 @@ class Measure(object):
           self.state.seconds_per_quarter = 60 / self.state.qpm
           if child.get('dynamics') is not None:
             self.state.velocity = int(child.get('dynamics'))
-
-      #if child.tag == 'direction-type':
-        #dynamics = child.tag('dynamics').text
-        #print('ff')
 
   def _parse_forward(self, xml_forward):
     """Parse the MusicXML <forward> element.
@@ -1403,12 +1400,21 @@ class Direction(object):
           self._parse_words(child)
 
   def _parse_pedal(self, xml_pedal):
-    """Parse the MusicXML <pedal> element."""
+    """Parse the MusicXML <pedal> element.
+    
+    Args:
+      xml_pedal: XML element with tag type 'pedal'.
+    """
+
     pedal = xml_pedal.attrib
     self.pedal = pedal
 
   def _parse_sound(self, xml_direction):
-    """Parse the MusicXML <sound> element."""
+    """Parse the MusicXML <sound> element.
+    
+    Args:
+      xml_direction: XML element with tag type 'direction'.
+    """
     sound_tag = xml_direction.find('sound')
     if sound_tag is not None:
       attrib = sound_tag.attrib
@@ -1418,17 +1424,28 @@ class Direction(object):
         self.tempo = attrib['tempo']
 
   def _parse_dynamics(self, xml_dynamics):
-    """Parse the MusicXML <dynamics> element."""
+    """Parse the MusicXML <dynamics> element.
+
+    Args:
+      xml_dynamics: XML element with tag type 'dynamics'.
+    """
     dynamic = xml_dynamics.getchildren()[0].tag
     self.dynamic = dynamic
 
   def _parse_wedge(self, xml_wedge):
-    """Parse the MusicXML <wedge> element."""
-    wedge = xml_wedge.attrib
-    self.wedge = wedge
+    """Parse the MusicXML <wedge> element.
+    
+    Args:
+      xml_wedge: XML element with tag type 'wedge'.
+    """
+    self.wedge = xml_wedge.attrib
 
   def _parse_words(self, xml_words):
-    """Parse the MusicXML <words> element."""
+    """Parse the MusicXML <words> element.
+    
+    Args:
+      xml_wedge: XML element with tag type 'wedge'.
+    """
     self.words = xml_words.text
 
 
@@ -1475,9 +1492,13 @@ class Notations(object):
         elif child.tag == 'tied':
           self.tied = child.attrib['type']
 
-  def _parse_articulations(self, child):
-    """Parse the MusicXML <Articulations> element."""
-    tag = child.getchildren()[0].tag
+  def _parse_articulations(self, xml_articulation):
+    """Parse the MusicXML <Articulations> element.
+
+    Args:
+      xml_articulation: XML element with tag type 'articulation'.
+    """
+    tag = xml_articulation.getchildren()[0].tag
     if tag == 'accent':
       self.arpeggiate = True
     elif tag == 'arpeggiate':

--- a/magenta/musicxml_parser.py
+++ b/magenta/musicxml_parser.py
@@ -508,6 +508,8 @@ class Measure(object):
     self.tempos = []
     self.time_signature = None
     self.key_signature = None
+    self.barline = None
+    self.repeat = None        # 'start' or 'stop' or None
     # Cumulative duration in MusicXML duration.
     # Used for time signature calculations
     self.duration = 0
@@ -528,6 +530,9 @@ class Measure(object):
         self._parse_attributes(child)
       elif child.tag == 'backup':
         self._parse_backup(child)
+      elif child.tag == 'barline':
+        # Get text in <bar-style /> and update barline
+        self._parse_barline(child)
       elif child.tag == 'direction':
         # Append new direction
         direction.append(child)
@@ -554,6 +559,26 @@ class Measure(object):
         # Ignore other tag types because they are not relevant.
         pass
 
+  def _parse_barline(self, xml_barline):
+    """Parse the MusicXML <bar-style> element.
+
+    Args:
+      xml_barline: XML element with tag type 'barline'.
+    """
+    style = xml_barline.find('bar-style').text
+    repeat = xml_barline.find('repeat')
+
+    if style == 'light-light':
+      self.barline = 'double'
+    elif style == 'light-heavy':
+      self.barline = 'final'
+    elif repeat is not None:
+      attrib = repeat.attrib['direction']
+      if attrib == 'forward':
+        self.repeat = 'start'
+      elif attrib == 'backword':
+        self.repeat = 'end'
+    
   def _parse_attributes(self, xml_attributes):
     """Parse the MusicXML <attributes> element."""
 


### PR DESCRIPTION
Issue: #11 
`Measure()` 에 두 프로퍼티 객체를 추가했습니다.
세 타입 중 하나를 `str`로 반환합니다.

* barline : double(겹세로줄), final(끝세로줄), None
* repeat: start(도돌이표 시작), stop(도돌이표 끝), None

http://usermanuals.musicxml.com/MusicXML/MusicXML.htm#EL-MusicXML-repeat.htm

